### PR TITLE
Use the ratgdo pins configured in the substitutions section

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -8,6 +8,9 @@ external_components:
 
 ratgdo:
   id: ${id_prefix}
+  input_gdo_pin: ${uart_rx_pin}
+  output_gdo_pin: ${uart_tx_pin}
+  input_obst_pin: ${input_obst_pin}
 
 sensor:
   - platform: ratgdo

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -4,6 +4,7 @@ substitutions:
   friendly_name: "RATGDOv2"
   uart_tx_pin: D4
   uart_rx_pin: D2
+  input_obst_pin: D7
   status_door_pin: D0
   status_obstruction_pin: D8
   dry_contact_open_pin: D5

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -4,6 +4,7 @@ substitutions:
   friendly_name: "ratgdov2"
   uart_tx_pin: D4
   uart_rx_pin: D2
+  input_obst_pin: D7
   status_door_pin: D0
   status_obstruction_pin: D8
   dry_contact_open_pin: D5


### PR DESCRIPTION
Currently the `ratgdo` component in `base.yaml` always uses the default pin values. 

This results in compilation failure for boards that don't have the `Dx` pin aliases and doesn't allow for pins to be customized. 