### PR TITLE
Add option for enable behaviour where light is triggered on by motion

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -8,6 +8,7 @@ external_components:
 
 ratgdo:
   id: ${id_prefix}
+  motion_triggers_light: ${motion_triggers_light}
 
 sensor:
   - platform: ratgdo

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -21,6 +21,8 @@ DEFAULT_INPUT_GDO = (
 )
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
+CONF_MOTION_TRIGGERS_LIGHT = "motion_triggers_light"
+DEFAULT_MOTION_TRIGGERS_LIGHT = "false"
 
 CONF_RATGDO_ID = "ratgdo_id"
 
@@ -36,6 +38,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(
             CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST
         ): pins.gpio_input_pin_schema,
+        cv.Optional(
+            CONF_MOTION_TRIGGERS_LIGHT, default=DEFAULT_MOTION_TRIGGERS_LIGHT
+        ): cv.boolean,
     }
 ).extend(cv.COMPONENT_SCHEMA)
 
@@ -60,6 +65,7 @@ async def to_code(config):
     cg.add(var.set_input_gdo_pin(pin))
     pin = await cg.gpio_pin_expression(config[CONF_INPUT_OBST])
     cg.add(var.set_input_obst_pin(pin))
+    cg.add(var.set_motion_triggers_light(config[CONF_MOTION_TRIGGERS_LIGHT]))
 
     cg.add_library(
         name="secplus",

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -74,6 +74,7 @@ namespace ratgdo {
         LOG_PIN("  Input GDO Pin: ", this->input_gdo_pin_);
         LOG_PIN("  Input Obstruction Pin: ", this->input_obst_pin_);
         ESP_LOGCONFIG(TAG, "  Rolling Code Counter: %d", this->rollingCodeCounter);
+        ESP_LOGCONFIG(TAG, "  Motion triggers light: %s", YESNO(this->motion_triggers_light_));
     }
 
     uint16_t RATGDOComponent::readRollingCode()
@@ -121,6 +122,9 @@ namespace ratgdo {
             ESP_LOGV(TAG, "Openings: %d", this->openings);
         } else if (cmd == 0x285) {
             this->motionState = MotionState::MOTION_STATE_DETECTED; // toggle bit
+            if (this->motion_triggers_light_ && this->lightState == LightState::LIGHT_STATE_OFF) {
+                this->lightState = LightState::LIGHT_STATE_ON;
+            }
             ESP_LOGV(TAG, "Motion: %d (toggle)", this->motionState);
         } else {
             // 0x84 -- is it used?

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -112,6 +112,7 @@ namespace ratgdo {
         void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; };
         void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; };
         void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; };
+        void set_motion_triggers_light(bool value) { this->motion_triggers_light_ = value; };
 
         /********************************** FUNCTION DECLARATION
          * *****************************************/
@@ -156,6 +157,7 @@ namespace ratgdo {
         InternalGPIOPin* output_gdo_pin_;
         InternalGPIOPin* input_gdo_pin_;
         InternalGPIOPin* input_obst_pin_;
+        bool motion_triggers_light_;
 
     }; // RATGDOComponent
 

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -9,6 +9,7 @@ substitutions:
   dry_contact_open_pin: D5
   dry_contact_close_pin: D6
   dry_contact_light_pin: D3
+  motion_triggers_light: false
 
 web_server:
 

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -9,6 +9,7 @@ substitutions:
   dry_contact_open_pin: D5
   dry_contact_close_pin: D6
   dry_contact_light_pin: D3
+  motion_triggers_light: false
 
 web_server:
 


### PR DESCRIPTION
In case of my garage opener the light turns on automatically when motion is detected, which causes the `ratdgo` light state to diverge from reality. This adds an option to enable the light to be switched on when motion is detected.