### PR TITLE
Use door stop command in place of toggle

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -177,7 +177,7 @@ button:
           id($id_prefix).query_openings();
 
   - platform: template
-    id: ${id_prefix}_test
+    id: ${id_prefix}_sync
     name: "Sync"
     entity_category: diagnostic
     on_press: 

--- a/base.yaml
+++ b/base.yaml
@@ -4,6 +4,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
+      ref: door_stop
     refresh: 1s
 
 ratgdo:

--- a/base.yaml
+++ b/base.yaml
@@ -4,7 +4,6 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
-      ref: door_stop
     refresh: 1s
 
 preferences:

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -548,6 +548,7 @@ namespace ratgdo {
     void RATGDOComponent::saveCounter(int threshold)
     {
         this->pref_.save(&this->rollingCodeCounter);
+        /*
         if (!this->lastSyncedRollingCodeCounter || this->rollingCodeCounter - this->lastSyncedRollingCodeCounter >= threshold) {
             // do flash write outside of the component loop
             defer([=] {
@@ -555,6 +556,7 @@ namespace ratgdo {
                 global_preferences->sync();
             });
         }
+        */
     }
 
     void RATGDOComponent::register_child(RATGDOClient* obj)

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -476,12 +476,12 @@ namespace ratgdo {
 
     void RATGDOComponent::openDoor()
     {
-        doorCommand(data::OPEN);
+        doorCommand(data::DOOR_OPEN);
     }
 
     void RATGDOComponent::closeDoor()
     {
-        doorCommand(data::CLOSE);
+        doorCommand(data::DOOR_CLOSE);
     }
 
     void RATGDOComponent::stopDoor()
@@ -490,12 +490,12 @@ namespace ratgdo {
             ESP_LOGV(TAG, "The door is not moving.");
             return;
         }
-        toggleDoor();
+        doorCommand(data::DOOR_STOP);
     }
 
     void RATGDOComponent::toggleDoor()
     {
-        doorCommand(data::TOGGLE);
+        doorCommand(data::DOOR_TOGGLE);
     }
 
     void RATGDOComponent::doorCommand(uint32_t data)
@@ -512,37 +512,37 @@ namespace ratgdo {
     void RATGDOComponent::lightOn()
     {
         this->lightState = LightState::LIGHT_STATE_ON;
-        transmit(command::LIGHT, data::ON);
+        transmit(command::LIGHT, data::LIGHT_ON);
     }
 
     void RATGDOComponent::lightOff()
     {
         this->lightState = LightState::LIGHT_STATE_OFF;
-        transmit(command::LIGHT, data::OFF);
+        transmit(command::LIGHT, data::LIGHT_OFF);
     }
 
     void RATGDOComponent::toggleLight()
     {
         this->lightState = light_state_toggle(this->lightState);
-        transmit(command::LIGHT, data::TOGGLE);
+        transmit(command::LIGHT, data::LIGHT_TOGGLE);
     }
 
     // Lock functions
     void RATGDOComponent::lock()
     {
         this->lockState = LockState::LOCK_STATE_LOCKED;
-        transmit(command::LOCK, data::ON);
+        transmit(command::LOCK, data::LOCK_ON);
     }
 
     void RATGDOComponent::unlock()
     {
-        transmit(command::LOCK, data::OFF);
+        transmit(command::LOCK, data::LOCK_OFF);
     }
 
     void RATGDOComponent::toggleLock()
     {
         this->lockState = lock_state_toggle(this->lockState);
-        transmit(command::LOCK, data::TOGGLE);
+        transmit(command::LOCK, data::LOCK_TOGGLE);
     }
 
     void RATGDOComponent::saveCounter(int threshold)

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -62,11 +62,19 @@ namespace ratgdo {
     */
 
     namespace data {
-        const uint32_t OFF = 0;
-        const uint32_t CLOSE = 0;
-        const uint32_t ON = 1;
-        const uint32_t OPEN = 1;
-        const uint32_t TOGGLE = 2;
+        const uint32_t LIGHT_OFF = 0;
+        const uint32_t LIGHT_ON = 1;
+        const uint32_t LIGHT_TOGGLE = 2;
+        const uint32_t LIGHT_TOGGLE2 = 3;
+
+        const uint32_t LOCK_OFF = 0;
+        const uint32_t LOCK_ON = 1;
+        const uint32_t LOCK_TOGGLE = 2;
+
+        const uint32_t DOOR_CLOSE = 0;
+        const uint32_t DOOR_OPEN = 1;
+        const uint32_t DOOR_TOGGLE = 2;
+        const uint32_t DOOR_STOP = 3;
     }
 
     namespace command {
@@ -176,7 +184,7 @@ namespace ratgdo {
         void toggleLock();
         void lock();
         void unlock();
-        
+
         void query_status();
         void query_openings();
 

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,7 +33,6 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
-    ref: door_stop
 
 # Sync time with Home Assistant.
 time:

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,6 +33,7 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
+    ref: door_stop
 
 # Sync time with Home Assistant.
 time:


### PR DESCRIPTION
Currently the door stop button actually send a door toggle command, which does stop the door when it's opening, but it reverses the direction when the door closes. 

I found that there is a stop command that actually stops the door in both cases. It's still possible to reverse the direction while closing the door by using the "open" button.