### PR TITLE
Fix crash when flash is written too frequently

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -6,6 +6,9 @@ external_components:
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
     refresh: 1s
 
+preferences:
+  flash_write_interval: 5s
+
 ratgdo:
   id: ${id_prefix}
   input_gdo_pin: ${uart_rx_pin}

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -176,7 +176,7 @@ namespace ratgdo {
         void toggleLock();
         void lock();
         void unlock();
-        
+
         void query_status();
         void query_openings();
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -160,7 +160,7 @@ namespace ratgdo {
         void obstructionLoop();
         void statusUpdateLoop();
 
-        void saveCounter(int threshold);
+        void saveCounter();
 
         void doorCommand(uint32_t data);
 


### PR DESCRIPTION
This fixes the soft reboot when hammering the light. There is some risk that we could increment the counter > 5 in 5s and than get an unhandled reset, but that seems really low.  I think its better to fix that crash and take a little bit of risk there.