### PR TITLE
Door position control

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -136,6 +136,22 @@ number:
     name: "Rolling code counter"
     mode: box
     unit_of_measurement: "codes"
+  
+  - platform: ratgdo
+    id: ${id_prefix}_opening_duration
+    type: opening_duration
+    entity_category: config
+    ratgdo_id: ${id_prefix}
+    name: "Opening duration"
+    unit_of_measurement: "s"
+
+  - platform: ratgdo
+    id: ${id_prefix}_closing_duration
+    type: closing_duration
+    entity_category: config
+    ratgdo_id: ${id_prefix}
+    name: "Closing duration"
+    unit_of_measurement: "s"
 
 cover:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -4,6 +4,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
+      ref: door_position
     refresh: 1s
 
 preferences:

--- a/base.yaml
+++ b/base.yaml
@@ -4,7 +4,6 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
-      ref: door_position
     refresh: 1s
 
 preferences:

--- a/components/ratgdo/cover/ratgdo_cover.cpp
+++ b/components/ratgdo/cover/ratgdo_cover.cpp
@@ -13,7 +13,7 @@ namespace ratgdo {
     {
         LOG_COVER("", "RATGDO Cover", this);
     }
-    void RATGDOCover::on_door_state(DoorState state)
+    void RATGDOCover::on_door_state(DoorState state, float position)
     {
         switch (state) {
         case DoorState::DOOR_STATE_OPEN:
@@ -26,15 +26,15 @@ namespace ratgdo {
             break;
         case DoorState::DOOR_STATE_OPENING:
             this->current_operation = COVER_OPERATION_OPENING;
-            this->position = 0.5;
+            this->position = position;
             break;
         case DoorState::DOOR_STATE_CLOSING:
             this->current_operation = COVER_OPERATION_CLOSING;
-            this->position = 0.5;
+            this->position = position;
             break;
         case DoorState::DOOR_STATE_STOPPED:
             this->current_operation = COVER_OPERATION_IDLE;
-            this->position = 0.5;
+            this->position = position;
         default:
             this->current_operation = COVER_OPERATION_IDLE;
 
@@ -66,6 +66,8 @@ namespace ratgdo {
                 this->parent_->openDoor();
             } else if (pos == COVER_CLOSED) {
                 this->parent_->closeDoor();
+            } else {
+                this->parent_->setDoorPosition(pos);
             }
         }
     }

--- a/components/ratgdo/cover/ratgdo_cover.h
+++ b/components/ratgdo/cover/ratgdo_cover.h
@@ -13,7 +13,7 @@ namespace ratgdo {
     public:
         void dump_config() override;
         cover::CoverTraits get_traits() override;
-        void on_door_state(DoorState state) override;
+        void on_door_state(DoorState state, float position) override;
 
     protected:
         void control(const cover::CoverCall& call) override;

--- a/components/ratgdo/number/__init__.py
+++ b/components/ratgdo/number/__init__.py
@@ -13,6 +13,8 @@ NumberType = ratgdo_ns.enum("NumberType")
 CONF_TYPE = "type"
 TYPES = {
     "rolling_code_counter": NumberType.RATGDO_ROLLING_CODE_COUNTER,
+    "opening_duration": NumberType.RATGDO_OPENING_DURATION,
+    "closing_duration": NumberType.RATGDO_CLOSING_DURATION,
 }
 
 

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -60,7 +60,6 @@ namespace ratgdo {
         } else if (this->number_type_ == RATGDO_CLOSING_DURATION) {
             this->parent_->setClosingDuration(value);
         }
-        // this->publish_state(value);
     }
 
 } // namespace ratgdo

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -10,17 +10,57 @@ namespace ratgdo {
     void RATGDONumber::dump_config()
     {
         LOG_NUMBER("", "RATGDO Number", this);
-        ESP_LOGCONFIG(TAG, "  Type: Rolling Code Counter");
+        if (this->number_type_ == RATGDO_ROLLING_CODE_COUNTER) {
+            ESP_LOGCONFIG(TAG, "  Type: Rolling Code Counter");
+        } else if (this->number_type_ == RATGDO_OPENING_DURATION) {
+            ESP_LOGCONFIG(TAG, "  Type: Opening Duration");
+        } else if (this->number_type_ == RATGDO_CLOSING_DURATION) {
+            ESP_LOGCONFIG(TAG, "  Type: Closing Duration");
+        }
+    }
+
+    void RATGDONumber::set_number_type(NumberType number_type_) 
+    { 
+        this->number_type_ = number_type_; 
+        if (this->number_type_ == RATGDO_OPENING_DURATION || this->number_type_ == RATGDO_CLOSING_DURATION) {
+            this->traits.set_step(0.1);
+        }
     }
 
     void RATGDONumber::on_rolling_code_change(uint32_t rollingCodeCounter)
     {
+        if (this->number_type_ != RATGDO_ROLLING_CODE_COUNTER) {
+            return;
+        }
         this->publish_state(rollingCodeCounter);
     }
+
+    void RATGDONumber::on_opening_duration_change(float duration)
+    {
+        if (this->number_type_ != RATGDO_OPENING_DURATION) {
+            return;
+        }
+        this->publish_state(duration);
+    }
+
+    void RATGDONumber::on_closing_duration_change(float duration)
+    {
+        if (this->number_type_ != RATGDO_CLOSING_DURATION) {
+            return;
+        }
+        this->publish_state(duration);
+    }
+
     void RATGDONumber::control(float value)
     {
-        this->parent_->setRollingCodeCounter(value);
-        this->publish_state(value);
+        if (this->number_type_ == RATGDO_ROLLING_CODE_COUNTER) {
+            this->parent_->setRollingCodeCounter(value);
+        } else if (this->number_type_ == RATGDO_OPENING_DURATION) {
+            this->parent_->setOpeningDuration(value);
+        } else if (this->number_type_ == RATGDO_CLOSING_DURATION) {
+            this->parent_->setClosingDuration(value);
+        }
+        // this->publish_state(value);
     }
 
 } // namespace ratgdo

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -10,15 +10,20 @@ namespace esphome {
 namespace ratgdo {
 
     enum NumberType {
-        RATGDO_ROLLING_CODE_COUNTER
+        RATGDO_ROLLING_CODE_COUNTER,
+        RATGDO_OPENING_DURATION,
+        RATGDO_CLOSING_DURATION,
     };
 
     class RATGDONumber : public number::Number, public RATGDOClient, public Component {
     public:
         void dump_config() override;
-        void set_number_type(NumberType number_type_) { this->number_type_ = number_type_; }
+        void set_number_type(NumberType number_type_);
 
         void on_rolling_code_change(uint32_t rollingCodeCounter) override;
+        void on_opening_duration_change(float duration) override;
+        void on_closing_duration_change(float duration) override;
+
         void control(float value) override;
 
     protected:

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -131,7 +131,9 @@ namespace ratgdo {
         uint32_t rollingCodeCounter { 0 };
         uint32_t lastSyncedRollingCodeCounter { 0 };
 
+        float startOpening { -1 };
         float openingDuration { 0 };
+        float startClosing { -1 };
         float closingDuration { 0 };
 
         uint8_t txRollingCode[CODE_LENGTH];

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -33,6 +33,8 @@ namespace ratgdo {
 
     static const uint8_t CODE_LENGTH = 19;
 
+    const float DOOR_POSITION_UNKNOWN = -1.0;
+
     /*
     from: https://github.com/argilo/secplus/blob/f98c3220356c27717a25102c0b35815ebbd26ccc/secplus.py#L540
     _WIRELINE_COMMANDS = {
@@ -129,6 +131,9 @@ namespace ratgdo {
         uint32_t rollingCodeCounter { 0 };
         uint32_t lastSyncedRollingCodeCounter { 0 };
 
+        float openingDuration { 0 };
+        float closingDuration { 0 };
+
         uint8_t txRollingCode[CODE_LENGTH];
         uint8_t rxRollingCode[CODE_LENGTH];
 
@@ -137,6 +142,10 @@ namespace ratgdo {
 
         DoorState previousDoorState { DoorState::DOOR_STATE_UNKNOWN };
         DoorState doorState { DoorState::DOOR_STATE_UNKNOWN };
+
+        float doorPosition { DOOR_POSITION_UNKNOWN };
+        float previousDoorPosition { DOOR_POSITION_UNKNOWN };
+        bool movingToPosition { false };
 
         LightState previousLightState { LightState::LIGHT_STATE_UNKNOWN };
         LightState lightState { LightState::LIGHT_STATE_UNKNOWN };
@@ -179,6 +188,10 @@ namespace ratgdo {
         void openDoor();
         void closeDoor();
         void stopDoor();
+        void setDoorPosition(float position);
+        void positionSyncWhileOpening(float delta, float update_period = 500);
+        void positionSyncWhileClosing(float delta, float update_period = 500);
+        void cancelPositionSyncCallbacks();
 
         void toggleLight();
         void lightOn();
@@ -197,12 +210,20 @@ namespace ratgdo {
         void incrementRollingCodeCounter();
         void sendRollingCodeChanged();
         void setRollingCodeCounter(uint32_t counter);
+
+        void setOpeningDuration(float duration);
+        void sendOpeningDuration();
+        void setClosingDuration(float duration);
+        void sendClosingDuration();
+
         LightState getLightState();
         /** Register a child component. */
         void register_child(RATGDOClient* obj);
 
     protected:
-        ESPPreferenceObject pref_;
+        ESPPreferenceObject rollingCodePref_;
+        ESPPreferenceObject openingDurationPref_;
+        ESPPreferenceObject closingDurationPref_;
         std::vector<RATGDOClient*> children_;
         bool rollingCodeUpdatesEnabled_ { true };
         bool forceUpdate_ { false };

--- a/components/ratgdo/ratgdo_child.cpp
+++ b/components/ratgdo/ratgdo_child.cpp
@@ -6,13 +6,15 @@
 namespace esphome {
 namespace ratgdo {
 
-    void RATGDOClient::on_door_state(DoorState state) {};
+    void RATGDOClient::on_door_state(DoorState state, float position) {};
     void RATGDOClient::on_light_state(LightState state) {};
     void RATGDOClient::on_lock_state(LockState state) {};
     void RATGDOClient::on_motion_state(MotionState state) {};
     void RATGDOClient::on_obstruction_state(ObstructionState state) {};
     void RATGDOClient::on_motor_state(MotorState state) {};
     void RATGDOClient::on_rolling_code_change(uint32_t rollingCodeCounter) {};
+    void RATGDOClient::on_opening_duration_change(float duration) {};
+    void RATGDOClient::on_closing_duration_change(float duration) {};
     void RATGDOClient::on_openings_change(uint32_t openings) {};
     void RATGDOClient::on_button_state(ButtonState state) {};
 

--- a/components/ratgdo/ratgdo_child.h
+++ b/components/ratgdo/ratgdo_child.h
@@ -13,13 +13,15 @@ namespace ratgdo {
 
     class RATGDOClient : public Parented<RATGDOComponent> {
     public:
-        virtual void on_door_state(DoorState state);
+        virtual void on_door_state(DoorState state, float position);
         virtual void on_light_state(LightState state);
         virtual void on_lock_state(LockState state);
         virtual void on_motion_state(MotionState state);
         virtual void on_obstruction_state(ObstructionState state);
         virtual void on_motor_state(MotorState state);
         virtual void on_rolling_code_change(uint32_t rollingCodeCounter);
+        virtual void on_opening_duration_change(float duration);
+        virtual void on_closing_duration_change(float duration);
         virtual void on_openings_change(uint32_t openings);
         virtual void on_button_state(ButtonState state);
 

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,7 +33,6 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
-    ref: door_position
 
 # Sync time with Home Assistant.
 time:

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,6 +33,7 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
+    ref: door_position
 
 # Sync time with Home Assistant.
 time:


### PR DESCRIPTION
This implements door position control using the time it takes the door to open/close. It's obviously open-loop, since there's no feedback from the GDO until the door hits the fully opened / closed positions, it optimistically syncs the door position in the UI every 0.5s .

However, I find it quite useful, many times I want to open the garage door just a little (10-15%) to let some air in and now I can do it in one step instead of opening&stopping it.

It adds two configuration parameters, opening_duration & closing_duration, probably the same in most cases, but can be different if needed. If these are not configured, it assumes middle position 50% as before.

