### PR TITLE
Make storing persistent state the resposibility of ratgdo_number

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ The ESPHome firmware will allow you to open the door to any position after calib
 <img width="560" alt="position_demo" src="https://github.com/ESPHome-RATGDO/esphome-ratgdo/assets/663432/22a9873e-67bb-4b2f-bb32-70047cfe666d">
 
 
+## Updating from versions older than 2023.07.07
+
+When updating from older versions, save the rolling counter value and restore it via the number entity after flashing the new firmware. If you forget to save the code, check the Home Assistant history.
+
 # ESPHome config
 
 - [ESPHome config for v2 board with ESP8266 D1 Mini lite](https://github.com/ESPHome-RATGDO/esphome-ratgdo/blob/main/static/v2board_esp8266_d1_mini_lite.yaml)

--- a/base.yaml
+++ b/base.yaml
@@ -22,7 +22,7 @@ ratgdo:
           service: persistent_notification.create
           data:
             title: "RATGDO sync failed"
-            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history."
+            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history. [esphome devices](/config/devices/dashboard?domain=esphome)""
 
 sensor:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -22,7 +22,8 @@ ratgdo:
           service: persistent_notification.create
           data:
             title: "${friendly_name} sync failed"
-            message: "Failed to communicate with garage opener on startup; Check the ${friendly_name} Rolling code counter number entity history and set the entity to one number larger than the largest value in history. [esphome devices](/config/devices/dashboard?domain=esphome)"
+            message: "Failed to communicate with garage opener on startup; Check the ${friendly_name} Rolling code counter number entity history and set the entity to one number larger than the largest value in history. [ESPHome devices](/config/devices/dashboard?domain=esphome)"
+            notification_id: "esphome_ratgdo_${id_prefix}_sync_failed"
 
 sensor:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -22,7 +22,7 @@ ratgdo:
           service: persistent_notification.create
           data:
             title: "${friendly_name} sync failed"
-            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history. [esphome devices](/config/devices/dashboard?domain=esphome)"
+            message: "Failed to communicate with garage opener on startup; Check the ${friendly_name} Rolling code counter number entity history and set the entity to one number larger than the largest value in history. [esphome devices](/config/devices/dashboard?domain=esphome)"
 
 sensor:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -15,6 +15,13 @@ ratgdo:
   output_gdo_pin: ${uart_tx_pin}
   input_obst_pin: ${input_obst_pin}
   remote_id: 0x539
+  on_sync_failed:
+    then:
+      - homeassistant.service:
+          service: persistent_notification.create
+          data:
+            title: "RATGDO sync failed"
+            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history."
 
 sensor:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -4,7 +4,6 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
-      ref: component_restore_state
     refresh: 1s
 
 preferences:

--- a/base.yaml
+++ b/base.yaml
@@ -22,7 +22,7 @@ ratgdo:
           service: persistent_notification.create
           data:
             title: "RATGDO sync failed"
-            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history. [esphome devices](/config/devices/dashboard?domain=esphome)""
+            message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history. [esphome devices](/config/devices/dashboard?domain=esphome)"
 
 sensor:
   - platform: ratgdo

--- a/base.yaml
+++ b/base.yaml
@@ -4,6 +4,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
+      ref: component_restore_state
     refresh: 1s
 
 preferences:

--- a/base.yaml
+++ b/base.yaml
@@ -21,7 +21,7 @@ ratgdo:
       - homeassistant.service:
           service: persistent_notification.create
           data:
-            title: "RATGDO sync failed"
+            title: "${friendly_name} sync failed"
             message: "Failed to communicate with garage opener on startup, check rolling code counter and restore from history. [esphome devices](/config/devices/dashboard?domain=esphome)"
 
 sensor:

--- a/components/ratgdo/automation.h
+++ b/components/ratgdo/automation.h
@@ -1,0 +1,22 @@
+
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/core/automation.h"
+#include "ratgdo.h"
+
+namespace esphome {
+namespace ratgdo {
+
+class SyncFailed: public Trigger<> {
+public:
+  explicit SyncFailed(RATGDOComponent *parent) {
+    parent->subscribe_sync_failed([this](bool state) {
+      if (state)
+        this->trigger();
+    });
+  }
+};
+
+}
+}

--- a/components/ratgdo/automation.h
+++ b/components/ratgdo/automation.h
@@ -1,22 +1,23 @@
 
 #pragma once
 
-#include "esphome/core/component.h"
 #include "esphome/core/automation.h"
+#include "esphome/core/component.h"
 #include "ratgdo.h"
 
 namespace esphome {
 namespace ratgdo {
 
-class SyncFailed: public Trigger<> {
-public:
-  explicit SyncFailed(RATGDOComponent *parent) {
-    parent->subscribe_sync_failed([this](bool state) {
-      if (state)
-        this->trigger();
-    });
-  }
-};
+    class SyncFailed : public Trigger<> {
+    public:
+        explicit SyncFailed(RATGDOComponent* parent)
+        {
+            parent->subscribe_sync_failed([this](bool state) {
+                if (state)
+                    this->trigger();
+            });
+        }
+    };
 
 }
 }

--- a/components/ratgdo/cover/ratgdo_cover.cpp
+++ b/components/ratgdo/cover/ratgdo_cover.cpp
@@ -16,6 +16,10 @@ namespace ratgdo {
 
     void RATGDOCover::setup()
     {
+        auto state = this->restore_state_();
+        if (state.has_value()) {
+            this->parent_->set_door_position(state.value().position);
+        }
         this->parent_->subscribe_door_state([=](DoorState state, float position) {
             this->on_door_state(state, position);
         });

--- a/components/ratgdo/light/ratgdo_light_output.cpp
+++ b/components/ratgdo/light/ratgdo_light_output.cpp
@@ -11,7 +11,7 @@ namespace ratgdo {
 
     void RATGDOLightOutput::dump_config()
     {
-        ESP_LOGCONFIG("", "RATGDO Light");
+        ESP_LOGCONFIG(TAG, "RATGDO Light");
     }
 
     void RATGDOLightOutput::setup()

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -56,13 +56,12 @@ namespace ratgdo {
             this->traits.set_max_value(0xfffffff);
         }
     }
-    
-    void RATGDONumber::update_state(float value) 
+
+    void RATGDONumber::update_state(float value)
     {
         this->pref_.save(&value);
         this->publish_state(value);
     }
-
 
     void RATGDONumber::control(float value)
     {

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -21,17 +21,25 @@ namespace ratgdo {
 
     void RATGDONumber::setup()
     {
+        float value;
+        this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+        if (!this->pref_.load(&value)) {
+            value = 0;
+        }
+        this->publish_state(value);
+        this->control(value);
+
         if (this->number_type_ == RATGDO_ROLLING_CODE_COUNTER) {
             this->parent_->subscribe_rolling_code_counter([=](uint32_t value) {
-                this->publish_state(value);
+                this->update_state(value);
             });
         } else if (this->number_type_ == RATGDO_OPENING_DURATION) {
             this->parent_->subscribe_opening_duration([=](float value) {
-                this->publish_state(value);
+                this->update_state(value);
             });
         } else if (this->number_type_ == RATGDO_CLOSING_DURATION) {
             this->parent_->subscribe_closing_duration([=](float value) {
-                this->publish_state(value);
+                this->update_state(value);
             });
         }
     }
@@ -48,6 +56,13 @@ namespace ratgdo {
             this->traits.set_max_value(0xfffffff);
         }
     }
+    
+    void RATGDONumber::update_state(float value) 
+    {
+        this->pref_.save(&value);
+        this->publish_state(value);
+    }
+
 
     void RATGDONumber::control(float value)
     {
@@ -58,6 +73,7 @@ namespace ratgdo {
         } else if (this->number_type_ == RATGDO_CLOSING_DURATION) {
             this->parent_->set_closing_duration(value);
         }
+        this->pref_.save(&value);
     }
 
 } // namespace ratgdo

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -18,12 +18,14 @@ namespace ratgdo {
     public:
         void dump_config() override;
         void setup() override;
-        void set_number_type(NumberType number_type_);
+        void set_number_type(NumberType number_type);
 
+        void update_state(float value);
         void control(float value) override;
 
     protected:
         NumberType number_type_;
+        ESPPreferenceObject pref_;
     };
 
 } // namespace ratgdo

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -20,9 +20,9 @@ namespace ratgdo {
         void setup() override;
         void set_number_type(NumberType number_type);
         // other esphome components that persist state in the flash have HARDWARE priority
-        // ensure we get initialized before them, so that the state doesn't get invalidated 
+        // ensure we get initialized before them, so that the state doesn't get invalidated
         // by components that might be added in the future
-        float get_setup_priority() const override { return setup_priority::HARDWARE + 1 ; }
+        float get_setup_priority() const override { return setup_priority::HARDWARE + 1; }
 
         void update_state(float value);
         void control(float value) override;

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -19,6 +19,7 @@ namespace ratgdo {
         void dump_config() override;
         void setup() override;
         void set_number_type(NumberType number_type);
+        float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
         void update_state(float value);
         void control(float value) override;

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -19,7 +19,10 @@ namespace ratgdo {
         void dump_config() override;
         void setup() override;
         void set_number_type(NumberType number_type);
-        float get_setup_priority() const override { return setup_priority::HARDWARE; }
+        // other esphome components that persist state in the flash have HARDWARE priority
+        // ensure we get initialized before them, so that the state doesn't get invalidated 
+        // by components that might be added in the future
+        float get_setup_priority() const override { return setup_priority::HARDWARE + 1 ; }
 
         void update_state(float value);
         void control(float value) override;

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -258,7 +258,7 @@ namespace ratgdo {
     void RATGDOComponent::print_packet(const WirePacket& packet) const
     {
         ESP_LOGV(TAG, "Counter: %d Send code: [%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X%02X]",
-            *this->rollingCodeCounter,
+            *this->rolling_code_counter,
             packet[0],
             packet[1],
             packet[2],

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -20,7 +20,7 @@ namespace esphome {
 namespace ratgdo {
 
     static const char* const TAG = "ratgdo";
-    static const int SYNC_DELAY = 20000;
+    static const int SYNC_DELAY = 1000;
     //
     // MAX_CODES_WITHOUT_FLASH_WRITE is a bit of a guess
     // since we write the flash at most every every 5s

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -404,6 +404,9 @@ namespace ratgdo {
                     if (*this->openings != 0) { // have openings
                         return RetryResult::DONE;
                     } else {
+                        if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                            this->sync_failed = true;
+                        };
                         this->transmit(Command::GET_OPENINGS);
                         return RetryResult::RETRY;
                     }

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -15,6 +15,7 @@
 #include "ratgdo_state.h"
 
 #include "esphome/core/log.h"
+#include "esphome/components/api/api_server.h"
 
 namespace esphome {
 namespace ratgdo {
@@ -408,6 +409,9 @@ namespace ratgdo {
                         return RetryResult::RETRY;
                     }
                 } else {
+                    if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                        this->sync_failed = true;
+                    };
                     this->transmit(Command::GET_STATUS);
                     return RetryResult::RETRY;
                 }
@@ -641,6 +645,10 @@ namespace ratgdo {
     void RATGDOComponent::subscribe_motion_state(std::function<void(MotionState)>&& f)
     {
         this->motion_state.subscribe([=](MotionState state) { defer("motion_state", [=] { f(state); }); });
+    }
+    void RATGDOComponent::subscribe_sync_failed(std::function<void(bool)>&& f)
+    {
+        this->sync_failed.subscribe(std::move(f));
     }
 
 } // namespace ratgdo

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -399,7 +399,7 @@ namespace ratgdo {
         this->increment_rolling_code_counter(MAX_CODES_WITHOUT_FLASH_WRITE);
 
         set_retry(
-            300, 10, [=](uint8_t r) {
+            500, 10, [=](uint8_t r) {
                 if (*this->door_state != DoorState::UNKNOWN) { // have status
                     if (*this->openings != 0) { // have openings
                         return RetryResult::DONE;

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -20,7 +20,7 @@ namespace esphome {
 namespace ratgdo {
 
     static const char* const TAG = "ratgdo";
-    static const int SYNC_DELAY = 1000;
+    static const int SYNC_DELAY = 20000;
     //
     // MAX_CODES_WITHOUT_FLASH_WRITE is a bit of a guess
     // since we write the flash at most every every 5s

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -15,7 +15,6 @@
 #include "ratgdo_state.h"
 
 #include "esphome/core/log.h"
-#include "esphome/components/api/api_server.h"
 
 namespace esphome {
 namespace ratgdo {

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -405,6 +405,7 @@ namespace ratgdo {
                         return RetryResult::DONE;
                     } else {
                         if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                            ESP_LOGD(TAG, "Triggering sync failed actions.");
                             this->sync_failed = true;
                         };
                         this->transmit(Command::GET_OPENINGS);
@@ -412,6 +413,7 @@ namespace ratgdo {
                     }
                 } else {
                     if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                        ESP_LOGD(TAG, "Triggering sync failed actions.");
                         this->sync_failed = true;
                     };
                     this->transmit(Command::GET_STATUS);

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -90,7 +90,7 @@ namespace ratgdo {
 
         uint16_t cmd = ((fixed >> 24) & 0xf00) | (data & 0xff);
         data &= ~0xf000; // clear parity nibble
-        
+
         Command cmd_enum = to_Command(cmd, Command::UNKNOWN);
 
         if ((fixed & 0xfffffff) == this->remote_id_) { // my commands
@@ -195,12 +195,13 @@ namespace ratgdo {
         } else if (cmd == Command::OPENINGS) {
             // nibble==0 if it's our request
             // update openings only from our request or if it's not unknown state
-            if (nibble==0 || *this->openings!=0) {
+            if (nibble == 0 || *this->openings != 0) {
                 this->openings = (byte1 << 8) | byte2;
                 ESP_LOGD(TAG, "Openings: %d", *this->openings);
             } else {
                 ESP_LOGD(TAG, "Ignoreing openings, not from our request");
-            }        } else if (cmd == Command::MOTION) {
+            }
+        } else if (cmd == Command::MOTION) {
             this->motion_state = MotionState::DETECTED;
             if (*this->light_state == LightState::OFF) {
                 this->transmit(Command::GET_STATUS);
@@ -409,7 +410,7 @@ namespace ratgdo {
                     if (*this->openings != 0) { // have openings
                         return RetryResult::DONE;
                     } else {
-                        if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                        if (r == 0) { // failed to sync probably rolling counter is wrong, notify
                             ESP_LOGD(TAG, "Triggering sync failed actions.");
                             this->sync_failed = true;
                         };
@@ -417,7 +418,7 @@ namespace ratgdo {
                         return RetryResult::RETRY;
                     }
                 } else {
-                    if (r==0) { // failed to sync probably rolling counter is wrong, notify
+                    if (r == 0) { // failed to sync probably rolling counter is wrong, notify
                         ESP_LOGD(TAG, "Triggering sync failed actions.");
                         this->sync_failed = true;
                     };

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -136,7 +136,6 @@ namespace ratgdo {
 
         void increment_rolling_code_counter(int delta = 1);
         void set_rolling_code_counter(uint32_t code);
-        void save_rolling_code_counter();
 
         // door
         void door_command(uint32_t data);
@@ -148,6 +147,7 @@ namespace ratgdo {
         void position_sync_while_opening(float delta, float update_period = 500);
         void position_sync_while_closing(float delta, float update_period = 500);
         void cancel_position_sync_callbacks();
+        void set_door_position(float door_position) { this->door_position = door_position; }
         void set_opening_duration(float duration);
         void set_closing_duration(float duration);
 
@@ -181,9 +181,6 @@ namespace ratgdo {
         void subscribe_motion_state(std::function<void(MotionState)>&& f);
         
     protected:
-        ESPPreferenceObject rolling_code_counter_pref_;
-        ESPPreferenceObject opening_duration_pref_;
-        ESPPreferenceObject closing_duration_pref_;
         RATGDOStore isr_store_ {};
         SoftwareSerial sw_serial_;
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -121,6 +121,8 @@ namespace ratgdo {
         observable<ButtonState> button_state { ButtonState::UNKNOWN };
         observable<MotionState> motion_state { MotionState::UNKNOWN };
 
+        observable<bool> sync_failed { false };
+
         void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
         void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
         void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
@@ -179,6 +181,7 @@ namespace ratgdo {
         void subscribe_motor_state(std::function<void(MotorState)>&& f);
         void subscribe_button_state(std::function<void(ButtonState)>&& f);
         void subscribe_motion_state(std::function<void(MotionState)>&& f);
+        void subscribe_sync_failed(std::function<void(bool)>&& f);
         
     protected:
         RATGDOStore isr_store_ {};

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -26,7 +26,6 @@ extern "C" {
 
 #include "ratgdo_state.h"
 
-
 namespace esphome {
 namespace ratgdo {
 
@@ -182,7 +181,7 @@ namespace ratgdo {
         void subscribe_button_state(std::function<void(ButtonState)>&& f);
         void subscribe_motion_state(std::function<void(MotionState)>&& f);
         void subscribe_sync_failed(std::function<void(bool)>&& f);
-        
+
     protected:
         RATGDOStore isr_store_ {};
         SoftwareSerial sw_serial_;

--- a/static/index.html
+++ b/static/index.html
@@ -190,6 +190,11 @@
         </p>
       </div>
 
+      <h3>Updating from versions older than 2023.07.07</h3>
+      <p>
+        When updating from older versions, save the rolling counter value and restore it via the number entity after flashing the new firmware. If you forget to save the code, check the Home Assistant history.
+      </p>
+
       <h3>Advanced Users</h3>
       <ul>
         <li>

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,7 +33,6 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
-    ref: component_restore_state
 
 # Sync time with Home Assistant.
 time:

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,6 +33,7 @@ packages:
     url: https://github.com/esphome-ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
+    ref: component_restore_state
 
 # Sync time with Home Assistant.
 time:


### PR DESCRIPTION
This moves the global preferences from the main ratgdo class to ratgdo_number which makes the code simpler and also changes the storage type from hard-coded values to the component's `get_object_id_hash()`.

I also persists the door position between reboots/upgrades.

**NOTE**: this is a breaking changes with respect to the values stored in flash, the rolling code, opening/closing times need to be saved/re-entered.