### PR TITLE
Fix obstruction isr for ESP32

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -53,10 +53,10 @@ namespace ratgdo {
         this->output_gdo_pin_->pin_mode(gpio::FLAG_OUTPUT);
         this->input_gdo_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
         this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT);
+        
+        this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction, &this->isr_store_, gpio::INTERRUPT_ANY_EDGE);
 
         this->sw_serial_.begin(9600, SWSERIAL_8N1, this->input_gdo_pin_->get_pin(), this->output_gdo_pin_->get_pin(), true);
-
-        this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction, &this->isr_store_, gpio::INTERRUPT_ANY_EDGE);
 
         ESP_LOGV(TAG, "Syncing rolling code counter after reboot...");
 


### PR DESCRIPTION
In RATGDOComponent::setup() call the ESPHome code to attach_interrupt() before software serial begin().  This allows ESPHome to call IDF gpio_install_isr_service() without error.

Tested on ESP32, fixes operation of the obstruction sensor from #36.  Still get an error in the logs presumably when software serial tries to call gpio_install_isr_service() during setup but connection to garage door works properly.

Needs to be tested on a ESP8266.