### PR TITLE
Make obstruction detection ignore spurrious detections 

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -4,6 +4,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
+      ref: obstruction_detection
     refresh: 1s
 
 preferences:

--- a/base.yaml
+++ b/base.yaml
@@ -4,7 +4,6 @@ external_components:
   - source:
       type: git
       url: https://github.com/esphome-ratgdo/esphome-ratgdo
-      ref: obstruction_detection
     refresh: 1s
 
 preferences:

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -308,16 +308,16 @@ namespace ratgdo {
         // If at least 3 low pulses are counted within 50ms, the door is awake, not obstructed and we don't have to check anything else
 
         const long CHECK_PERIOD = 50;
-        const long PULSES_EXPECTED = CHECK_PERIOD/7;
+        const long PULSES_LOWER_LIMIT = 3;
 
         if (current_millis - last_millis > CHECK_PERIOD) {
-            ESP_LOGD(TAG, "[%ld: Obstruction count: %d, expected: %d, since asleep: %ld", 
-                 current_millis, this->isr_store_.obstruction_low_count, PULSES_EXPECTED,
-                 current_millis - last_asleep
-            );
+            // ESP_LOGD(TAG, "%ld: Obstruction count: %d, expected: %d, since asleep: %ld", 
+            //     current_millis, this->isr_store_.obstruction_low_count, PULSES_EXPECTED,
+            //     current_millis - last_asleep
+            // );
 
-            // check to see if we got between 3 and PULSES_EXPECTED + 1 low pulses on the line
-            if (this->isr_store_.obstruction_low_count >= 3 && this->isr_store_.obstruction_low_count <= PULSES_EXPECTED + 1) {
+            // check to see if we got more then PULSES_LOWER_LIMIT pulses
+            if (this->isr_store_.obstruction_low_count > PULSES_LOWER_LIMIT) {
                 this->obstruction_state = ObstructionState::CLEAR;
             } else if (this->isr_store_.obstruction_low_count == 0) {
                 // if there have been no pulses the line is steady high or low

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -33,11 +33,6 @@ namespace ratgdo {
     //
     static const uint8_t MAX_CODES_WITHOUT_FLASH_WRITE = 10;
 
-    void IRAM_ATTR HOT RATGDOStore::isr_obstruction(RATGDOStore* arg)
-    {
-        arg->obstruction_low_count++;
-    }
-
     void RATGDOComponent::setup()
     {
         this->output_gdo_pin_->setup();

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -311,10 +311,10 @@ namespace ratgdo {
         const long PULSES_EXPECTED = CHECK_PERIOD/7;
 
         if (current_millis - last_millis > CHECK_PERIOD) {
-            // ESP_LOGD(TAG, "[%ld: Obstruction count: %d, expected: %d, since asleep: %ld", 
-            //     current_millis, this->isr_store_.obstruction_low_count, PULSES_EXPECTED,
-            //     current_millis - last_asleep
-            // );
+            ESP_LOGD(TAG, "[%ld: Obstruction count: %d, expected: %d, since asleep: %ld", 
+                 current_millis, this->isr_store_.obstruction_low_count, PULSES_EXPECTED,
+                 current_millis - last_asleep
+            );
 
             // check to see if we got between 3 and PULSES_EXPECTED + 1 low pulses on the line
             if (this->isr_store_.obstruction_low_count >= 3 && this->isr_store_.obstruction_low_count <= PULSES_EXPECTED + 1) {

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -89,7 +89,6 @@ namespace ratgdo {
         ISRInternalGPIOPin input_obst;
 
         int obstruction_low_count = 0; // count obstruction low pulses
-        long last_obstruction_high = 0; // count time between high pulses from the obst ISR
 
         static void IRAM_ATTR HOT isr_obstruction(RATGDOStore* arg);
     };

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -86,11 +86,12 @@ namespace ratgdo {
     inline bool operator==(const Command& cmd_e, const uint16_t cmd_i) { return cmd_i == static_cast<uint16_t>(cmd_e); }
 
     struct RATGDOStore {
-        ISRInternalGPIOPin input_obst;
-
         int obstruction_low_count = 0; // count obstruction low pulses
 
-        static void IRAM_ATTR HOT isr_obstruction(RATGDOStore* arg);
+        static void IRAM_ATTR HOT isr_obstruction(RATGDOStore* arg) 
+        {
+            arg->obstruction_low_count++;
+        }
     };
 
     class RATGDOComponent : public Component {


### PR DESCRIPTION
Make obstruction detection ignore spurrious detections when sensors awake from sleep mode, for example when light is turned on.

Fixes #40.